### PR TITLE
Add IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 bin/*
 .vs/*
 obj/*
+/packages/
+!packages/repositories.config

--- a/Geoblocker.cs
+++ b/Geoblocker.cs
@@ -182,7 +182,7 @@ namespace IISGeoIP2blockModule
         {
             if (String.IsNullOrEmpty(exceptionRule.Mask) && IPAddress.Parse(exceptionRule.IpAddress).Equals(ipAddress))
                 return true;
-            if (!String.IsNullOrEmpty(exceptionRule.Mask) && IPUtilities.IsInSameSubnet(ipAddress, IPAddress.Parse(exceptionRule.IpAddress), IPAddress.Parse(exceptionRule.Mask)))
+            if (!String.IsNullOrEmpty(exceptionRule.Mask) && IPUtilities.IsInSameSubnet(ipAddress, exceptionRule.IpAddress, exceptionRule.Mask))
                 return true;
             return false;
         }

--- a/IPUtilities.cs
+++ b/IPUtilities.cs
@@ -86,8 +86,7 @@ namespace IISGeoIP2blockModule
         /// <returns>True if the IP addresses are within the same subnet. False otherwise</returns>
         public static bool IsInSameSubnet(string ipAddress1, string ipAddress2, string subnetMask)
         {
-            var range = IPAddressRange.Parse(ipAddress2 + "/" + subnetMask);
-            return range.Contains(IPAddress.Parse(ipAddress1));
+            return IsInSameSubnet(IPAddress.Parse(ipAddress1), ipAddress2, subnetMask);
         }
 
         /// <summary>

--- a/IPUtilities.cs
+++ b/IPUtilities.cs
@@ -14,8 +14,10 @@
  * General Public License for more details.
  */
 
+using NetTools;
 using System;
 using System.Net;
+using System.Net.Sockets;
 
 namespace IISGeoIP2blockModule
 {
@@ -31,30 +33,47 @@ namespace IISGeoIP2blockModule
         /// <returns>True if the IP address is a private IP address. False otherwise</returns>
         public static bool IsPrivateIpAddress(IPAddress ipAddress)
         {
-            //127.0.0.1 is also a candidate
-            if (ipAddress.Equals(IPAddress.Parse("127.0.0.1")))
-                return true;
+            if (ipAddress.AddressFamily == AddressFamily.InterNetwork)
+            {
+                //IPv4 Loopback
+                var rangeIpv4Loopback = IPAddressRange.Parse("127.0.0.0/8");
+                //IPv4 Private
+                var rangeIpv4Priv1 = IPAddressRange.Parse("10.0.0.0/8");
+                var rangeIpv4Priv2 = IPAddressRange.Parse("172.16.0.0/12");
+                var rangeIpv4Priv3 = IPAddressRange.Parse("192.168.0.0/16");
+                //IPv4 Link Local
+                var rangeIpv4Local = IPAddressRange.Parse("169.254.0.0/16");
 
-            //24-bit block	10.0.0.0 – 10.255.255.255	16,777,216	single class A	10.0.0.0/8 (255.0.0.0)	24 bits
-            //20-bit block	172.16.0.0 – 172.31.255.255	1,048,576	16 contiguous class Bs	172.16.0.0/12 (255.240.0.0)	20 bits
-            //16-bit block	192.168.0.0 – 192.168.255.255	65,536	256 contiguous class Cs	192.168.0.0/16 (255.255.0.0)	16 bits
+                //Loopback
+                if (rangeIpv4Loopback.Contains(ipAddress))
+                    return true;
+                //Private
+                if (rangeIpv4Priv1.Contains(ipAddress) || rangeIpv4Priv2.Contains(ipAddress) || rangeIpv4Priv3.Contains(ipAddress))
+                    return true;
+                //Link Local
+                if (rangeIpv4Local.Contains(ipAddress))
+                    return true;
+            }
+            else if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                //IPv6 Loopback
+                var rangeIpv6Loopback = IPAddressRange.Parse("::1/128");
+                //IPv6 Unique Local
+                var rangeIpv6Priv = IPAddressRange.Parse("fc00::/7");
+                //IPv6 Link Local
+                var rangeIpv6Local = IPAddressRange.Parse("fe80::/10");
 
-            //private ranges
-            IPAddress private24Subnet = IPAddress.Parse("10.0.0.1");
-            IPAddress private24SubnetMask = IPAddress.Parse("255.0.0.0");
+                //Loopback
+                if (rangeIpv6Loopback.Contains(ipAddress))
+                    return true;
+                //Unique Local
+                if (rangeIpv6Priv.Contains(ipAddress))
+                    return true;
+                //Link Local
+                if (rangeIpv6Local.Contains(ipAddress))
+                    return true;
+            }
 
-            IPAddress private20Subnet = IPAddress.Parse("172.16.0.0");
-            IPAddress private20SubnetMask = IPAddress.Parse("255.240.0.0");
-
-            IPAddress private16Subnet = IPAddress.Parse("192.168.0.0");
-            IPAddress private16SubnetMask = IPAddress.Parse("255.255.0.0");
-
-            if (IsInSameSubnet(ipAddress, private16Subnet, private16SubnetMask))
-                return true;
-            if (IsInSameSubnet(ipAddress, private20Subnet, private20SubnetMask))
-                return true;
-            if (IsInSameSubnet(ipAddress, private24Subnet, private24SubnetMask))
-                return true;
             return false;
         }
 
@@ -67,7 +86,8 @@ namespace IISGeoIP2blockModule
         /// <returns>True if the IP addresses are within the same subnet. False otherwise</returns>
         public static bool IsInSameSubnet(string ipAddress1, string ipAddress2, string subnetMask)
         {
-            return IsInSameSubnet(IPAddress.Parse(ipAddress1), IPAddress.Parse(ipAddress2), IPAddress.Parse(subnetMask));
+            var range = IPAddressRange.Parse(ipAddress2 + "/" + subnetMask);
+            return range.Contains(IPAddress.Parse(ipAddress1));
         }
 
         /// <summary>
@@ -77,34 +97,10 @@ namespace IISGeoIP2blockModule
         /// <param name="ipAddress2">IP address 2</param>
         /// <param name="subnetMask">The subnet</param>
         /// <returns>True if the IP addresses are within the same subnet. False otherwise</returns>
-        public static bool IsInSameSubnet(IPAddress ipAddress1, IPAddress ipAddress2, IPAddress subnetMask)
+        public static bool IsInSameSubnet(IPAddress ipAddress1, string ipAddress2, string subnetMask)
         {
-            IPAddress network1 = GetNetworkAddress(ipAddress1, subnetMask);
-            IPAddress network2 = GetNetworkAddress(ipAddress2, subnetMask);
-
-            return network1.Equals(network2);
-        }
-
-        /// <summary>
-        /// Gets the network address based on an address and the subnetmask
-        /// </summary>
-        /// <param name="ipAddress">The IP address</param>
-        /// <param name="subnetMask">The subnet mask</param>
-        /// <returns>The (broadcast) network address</returns>
-        public static IPAddress GetNetworkAddress(IPAddress ipAddress, IPAddress subnetMask)
-        {
-            byte[] ipAdressBytes = ipAddress.GetAddressBytes();
-            byte[] subnetMaskBytes = subnetMask.GetAddressBytes();
-
-            if (ipAdressBytes.Length != subnetMaskBytes.Length)
-                throw new ArgumentException("Lengths of IP address and subnet must be equal.");
-
-            byte[] broadcastAddress = new byte[ipAdressBytes.Length];
-            for (int i = 0; i < broadcastAddress.Length; i++)
-            {
-                broadcastAddress[i] = (byte)(ipAdressBytes[i] & (subnetMaskBytes[i]));
-            }
-            return new IPAddress(broadcastAddress);
+            var range = IPAddressRange.Parse(ipAddress2 + "/" + subnetMask);
+            return range.Contains(ipAddress1);
         }
     }
 }

--- a/IisGeoIP2blockModule.csproj
+++ b/IisGeoIP2blockModule.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\ILMerge.3.0.21\build\ILMerge.props" Condition="Exists('packages\ILMerge.3.0.21\build\ILMerge.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -60,17 +61,20 @@
     <CodeAnalysisRuleSet />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IPAddressRange, Version=3.2.0.0, Culture=neutral, PublicKeyToken=578e3c3d17e7c751, processorArchitecture=MSIL">
+      <HintPath>packages\IPAddressRange.3.2.0\lib\net45\IPAddressRange.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.CSharp">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>%windir%\System32\inetsrv\Microsoft.Web.Administration.dll</HintPath>
+      <HintPath>lib\Microsoft.Web.Administration.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.Web.Management, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>%windir%\System32\inetsrv\Microsoft.Web.Management.dll</HintPath>
+    <Reference Include="Microsoft.Web.Management">
+      <HintPath>lib\Microsoft.Web.Management.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -90,7 +94,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AddExceptionRuleForm.cs" />
+    <Compile Include="AddExceptionRuleForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="AddExceptionRuleForm.Designer.cs">
       <DependentUpon>AddExceptionRuleForm.cs</DependentUpon>
     </Compile>
@@ -146,6 +152,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="IisGeoblockModule.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AddExceptionRuleForm.resx">
@@ -177,6 +184,14 @@
     <Folder Include="MaxMind.GeoIP2\Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="packages\ILMerge.MSBuild.Task.1.0.5\build\ILMerge.MSBuild.Task.targets" Condition="Exists('packages\ILMerge.MSBuild.Task.1.0.5\build\ILMerge.MSBuild.Task.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\ILMerge.MSBuild.Task.1.0.5\build\ILMerge.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ILMerge.MSBuild.Task.1.0.5\build\ILMerge.MSBuild.Task.targets'))" />
+    <Error Condition="!Exists('packages\ILMerge.3.0.21\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ILMerge.3.0.21\build\ILMerge.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ILMerge" version="3.0.21" targetFramework="net46" />
+  <package id="ILMerge.MSBuild.Task" version="1.0.5" targetFramework="net46" />
+  <package id="IPAddressRange" version="3.2.0" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
This may not work in all cases and has not been fully tested as I have no primary-IPv6 machines on hand or the time to spin them on VirtualBox. Having said that, once compiled it no longer produces errors in Event Log related to host address not matching a defined mask.

Please note it replaces first-party address matching with a library, which you may or may not be comfortable with. If you're fine with this approach I can submit a PR for a similar thing done to MaxMind libraries which have been released as nuget packages by MaxMind, obviating the need to have their .cs files in GeoIP.